### PR TITLE
Fix 카카오, 네이버 간편 로그인후 회원가입 처리가 되지 않는 문제 해결

### DIFF
--- a/out/production/resources/application.yml
+++ b/out/production/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev
+    active: local

--- a/src/main/java/com/arton/backend/auth/application/service/KaKaoService.java
+++ b/src/main/java/com/arton/backend/auth/application/service/KaKaoService.java
@@ -3,6 +3,8 @@ package com.arton.backend.auth.application.service;
 import com.arton.backend.auth.application.port.in.KaKaoUseCase;
 import com.arton.backend.auth.application.port.in.TokenDto;
 import com.arton.backend.infra.jwt.TokenProvider;
+import com.arton.backend.infra.shared.exception.CustomException;
+import com.arton.backend.infra.shared.exception.ErrorCode;
 import com.arton.backend.user.application.port.out.UserRepositoryPort;
 import com.arton.backend.user.domain.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -167,7 +169,7 @@ public class KaKaoService implements KaKaoUseCase {
                     .build();
             userRepository.save(user);
         }
-        return user;
+        return userRepository.findByKakaoId(id).orElseThrow(()->new CustomException(ErrorCode.KAKAO_SIMPLE_LOGIN_ERROR.getMessage(), ErrorCode.KAKAO_SIMPLE_LOGIN_ERROR));
     }
 
 

--- a/src/main/java/com/arton/backend/auth/application/service/NaverService.java
+++ b/src/main/java/com/arton/backend/auth/application/service/NaverService.java
@@ -5,6 +5,8 @@ import com.arton.backend.auth.application.port.in.KaKaoUseCase;
 import com.arton.backend.auth.application.port.in.NaverUseCase;
 import com.arton.backend.auth.application.port.in.TokenDto;
 import com.arton.backend.infra.jwt.TokenProvider;
+import com.arton.backend.infra.shared.exception.CustomException;
+import com.arton.backend.infra.shared.exception.ErrorCode;
 import com.arton.backend.user.adapter.out.repository.UserEntity;
 import com.arton.backend.user.application.port.out.UserRepositoryPort;
 import com.arton.backend.user.domain.*;
@@ -74,7 +76,7 @@ public class NaverService implements NaverUseCase {
         Authentication authenticate = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         TokenDto tokenDto = tokenProvider.generateToken(authenticate);
         redisTemplate.opsForValue().set(refreshTokenPrefix+authenticate.getName(), tokenDto.getRefreshToken(), tokenDto.getRefreshTokenExpiresIn(), TimeUnit.MILLISECONDS);
-        return null;
+        return tokenDto;
     }
 
     /**
@@ -176,7 +178,7 @@ public class NaverService implements NaverUseCase {
                     .build();
             userRepository.save(user);
         }
-        return user;
+        return userRepository.findByNaverId(id).orElseThrow(() -> new CustomException(ErrorCode.NAVER_SIMPLE_LOGIN_ERROR.getMessage(), ErrorCode.NAVER_SIMPLE_LOGIN_ERROR));
     }
 
     private Gender getGender(String gender){

--- a/src/main/java/com/arton/backend/infra/shared/exception/ErrorCode.java
+++ b/src/main/java/com/arton/backend/infra/shared/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     USER_NOT_AUTHORITY(403, "COMMON-ERR-403", "권한이 없습니다."),
     TOKEN_INVALID(401, "TOKEN_ERR", "유효하지 않은 토큰입니다."),
     MAIL_SEND_ERROR(500, "MAIL_SEND_ERROR", "메일 발송에 실패하였습니다."),
+    KAKAO_SIMPLE_LOGIN_ERROR(500, "KAKAO_SIMPLE_LOGIN_ERROR", "카카오 간편 로그인에 실패하였습니다."),
+    NAVER_SIMPLE_LOGIN_ERROR(500, "NAVER_SIMPLE_LOGIN_ERROR", "네이버 간편 로그인에 실패하였습니다."),
     INVALID_URI_REQUEST(400, "INVALID_URI_REQUEST", "잘못된 URI 요청입니다."),
     SELECT_ERROR(404, "SELECT_ERROR", "조회에 실패 했습니다.");
     private int status;


### PR DESCRIPTION
기존 Entity 사용시 JPA에서 영속성 관리를 하기 때문에 id 값이 있어서 문제가 되지 않았는데 domain으로 바뀌면서 문제가 된것임.. 결국 id가 null 이 반환되고 시큐리티에서 토큰 발급하다 에러가 나서 트랜잭션 롤백이 되던것임. 이를 마지막에 다시 회원가입 체크를 하며 회원을 반환해 새로 발급된 id를 리턴하게 변경하여 회원가입 처리를 완료함.